### PR TITLE
Add environment getter and setters for loadScene

### DIFF
--- a/configurator/index.js
+++ b/configurator/index.js
@@ -1171,6 +1171,9 @@ var setModelFromS3 = function(rootUrl, fileName) {
   var getElementLink = function(elementID) {
     return turnerVECMain.viewerAPI.getElementLink(elementID)
   }
+  var getEnvironment = function() {
+    return turnerVECMain.viewerAPI.getEnvironmentMapCustomURL()
+  }
   var getCustomCSS = function() {
     var turnerCustomCSS = ''
   

--- a/viewer/scripts/turner.js
+++ b/viewer/scripts/turner.js
@@ -260,7 +260,7 @@ function addOSNormalMapPluginHook(bjsLoaderPlugin)
 }
 
 //TODO: this function is not very clean - there should be a clear separation between init code and model loading code
-function loadScene(rootUrl = '', fileName = 'scene.glb') {
+function loadScene(rootUrl = '', fileName = 'scene.glb', environment = 'images/environment.dds') {
     
     if (engine) {
         engine.dispose();
@@ -343,7 +343,7 @@ function loadScene(rootUrl = '', fileName = 'scene.glb') {
         camera.attachControl(canvas, true);   
         
         // setup environment
-        sceneObj.environmentTexture = new BABYLON.CubeTexture.CreateFromPrefilteredData("images/environment.dds", sceneObj);
+        sceneObj.environmentTexture = new BABYLON.CubeTexture.CreateFromPrefilteredData(environment, sceneObj);
 
         currentSkyboxScale     = 4.0 * camera.upperRadiusLimit;
         currentSkyboxBlurLevel = 0.5;


### PR DESCRIPTION
This PR adds a parameter to the `loadScene()` function to specify an environment map, allowing to initialize a new viewer directly with that environment instead of loading it after initializing.

It also adds a convenience method for getting the environment in the configurator.